### PR TITLE
build: supprime et recréé la base de données

### DIFF
--- a/knex/config-api.js
+++ b/knex/config-api.js
@@ -10,15 +10,21 @@ const connection = {
 }
 
 const knexConfig = {
-  client: 'pg',
-  connection,
-  migrations: {
-    directory: './knex/migrations'
+  knex: {
+    client: 'pg',
+    connection,
+    migrations: {
+      directory: './knex/migrations'
+    },
+    seeds: {
+      directory: './knex/seeds'
+    },
+    ...knexSnakeCaseMappers()
   },
-  seeds: {
-    directory: './knex/seeds'
-  },
-  ...knexSnakeCaseMappers()
+  dbManager: {
+    superUser: connection.user,
+    superPassword: connection.password
+  }
 }
 
 module.exports = knexConfig

--- a/knex/index.js
+++ b/knex/index.js
@@ -1,7 +1,9 @@
 const Knex = require('knex')
-const knexConfig = require('./config-api')
-const knex = Knex(knexConfig)
+const config = require('./config-api')
+const knex = Knex(config.knex)
 const chalk = require('chalk')
+
+const dbManager = require('knex-db-manager').databaseManagerFactory(config)
 
 const run = new Promise((resolve, reject) => {
   resolve()
@@ -18,6 +20,12 @@ const exit = text => {
 }
 
 run
+  .then(() => {
+    return dbManager.dropDb('camino')
+  })
+  .then(() => {
+    return dbManager.createDb('camino')
+  })
   .then(() => {
     console.log('Rollback')
     return knex.migrate

--- a/package-lock.json
+++ b/package-lock.json
@@ -7470,6 +7470,17 @@
         }
       }
     },
+    "knex-db-manager": {
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/knex-db-manager/-/knex-db-manager-0.5.0.tgz",
+      "integrity": "sha512-UN52j9h6riHV8cMSPEWqMY2FcG/ABjCeuXBX8oN4iRnLtlTsSdjibFosLn22myBXJUr1wMmm6SjHMsL2TQwCaA==",
+      "requires": {
+        "bluebird": "^3.5.1",
+        "glob": "^7.1.2",
+        "knex": "^0.16.3",
+        "lodash": "^4.17.11"
+      }
+    },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
@@ -8934,6 +8945,11 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.0.0.tgz",
       "integrity": "sha1-Pu/lmX4G2Ugh5NUC5CtqHHP434I="
+    },
+    "pg-escape": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/pg-escape/-/pg-escape-0.2.0.tgz",
+      "integrity": "sha1-ZVlMFpFlm0q24Mu/nVB0S+R0mY4="
     },
     "pg-int8": {
       "version": "1.0.1",

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   "scripts": {
     "build": "rm -rf dist && npx tsc",
     "dev": "nodemon",
-    "import": "mkdir -p sources && node ./dist/tools/import/index.js",
+    "import": "rm -rf sources && mkdir sources && node ./dist/tools/import/index.js",
     "dev:import": "ts-node --transpile-only ./src/tools/import/index.js",
     "export": "node ./dist/tools/export/index.js",
     "dev:export": "ts-node --transpile-only ./src/tools/export/index.js",
@@ -78,6 +78,7 @@
     "graphql-iso-date": "^3.6.1",
     "jsonwebtoken": "^8.5.1",
     "knex": "0.16.3",
+    "knex-db-manager": "^0.5.0",
     "make-dir": "^2.1.0",
     "node-fetch": "^2.3.0",
     "nodemailer": "^6.0.0",
@@ -86,6 +87,7 @@
     "objection": "^1.6.6",
     "p-queue": "^4.0.0",
     "pg": "^7.9.0",
+    "pg-escape": "^0.2.0",
     "typescript": "^3.3.4000"
   },
   "devDependencies": {

--- a/src/tools/import/index.js
+++ b/src/tools/import/index.js
@@ -28,14 +28,18 @@ const spreadsheetToJsonFiles = async ({ id, name, tables, prefixFileName }) => {
   console.log(`Spreadheet: ${name}`)
 
   try {
+    // construit la liste avec un fichier par table
     const filesList = filesListBuild({ name, tables, prefixFileName })
 
+    // récupère un tableau avec une entrée { range, majorDimension, values }
     const res = await spreadsheetsGet(
       credentials,
       id,
       filesList.map(({ worksheetName }) => worksheetName)
     )
 
+    // converti la réponse en json
+    // la première ligne de value forme les clés
     const jsons = res.map(r => rowsToJson(r.values.shift(), r.values))
 
     filesList.forEach(({ path, cb }, i) => {


### PR DESCRIPTION
utilise knex-db-manager et l'api de migration de knex pour faciliter la migration. fonctionne avec `npm run migrate-api`
