### PR TITLE
fix(api): corrige la disparition des périmètres dans le formatage

### DIFF
--- a/src/api/resolvers/_titre-eager-format.js
+++ b/src/api/resolvers/_titre-eager-format.js
@@ -6,6 +6,10 @@ const fieldsPropsEtapes = ['surface', 'volume', 'engagement']
 
 // ajoute des propriétés requises par /database/queries/_format
 const titreEagerFormat = (fields, parent) => {
+  // copie le premier paramètre
+  // empêche la modification de l'objet d'origine
+  fields = JSON.parse(JSON.stringify(fields))
+
   // ajoute la propriété `type` sur les administrations
   if (
     fields.administrations &&


### PR DESCRIPTION
@francoisromain On peut en discuter lundi.

En gros : l'objet `fields` est modifié pendant le `titreEagerFormat`, ce qui coince au `titreFormat` (les propriétés geojson disparaissent toutes).

Cette correction temporaire permet de faire un deep-copy de l'objet.