### PR TITLE
fix(seed): corrige l'import en base des fichiers volumineux

### DIFF
--- a/knex/seeds/4-repertoire.js
+++ b/knex/seeds/4-repertoire.js
@@ -3,19 +3,19 @@ const seeding = require('../seeding')
 
 const domaines = ['c', 'f', 'g', 'h', 'm', 'r', 's', 'w']
 
-const entreprises = domaines.reduce((acc, domaine) => {
-  acc.push(...require(`../../sources/entreprises-titres-${domaine}`))
+const entreprises = domaines.reduce(
+  (acc, domaine) =>
+    acc.concat(require(`../../sources/entreprises-titres-${domaine}`)),
+  []
+)
 
-  return acc
-}, [])
-
-const entreprisesEtablissements = domaines.reduce((acc, domaine) => {
-  acc.push(
-    ...require(`../../sources/entreprises-titres-${domaine}-etablissements`)
-  )
-
-  return acc
-}, [])
+const entreprisesEtablissements = domaines.reduce(
+  (acc, domaine) =>
+    acc.concat(
+      require(`../../sources/entreprises-titres-${domaine}-etablissements`)
+    ),
+  []
+)
 
 const administrations = require('../../sources/administrations.json')
 const administrationsTypes = require('../../sources/administrations-types.json')

--- a/knex/seeds/7-titres.js
+++ b/knex/seeds/7-titres.js
@@ -28,7 +28,8 @@ const data = files.reduce((d, file) => {
     let content
     try {
       content = require(`../../sources/${fileName}.json`)
-      res.push(...content)
+
+      return res.concat(content)
     } catch (e) {
       console.log(chalk.red(e.message.split('\n')[0]))
     }


### PR DESCRIPTION
Pour l'import du RNTM, avec 140K points, on a l'erreur `Maximum call stack`.