### PR TITLE
refactor(business): généralise le format string pour les dates

### DIFF
--- a/src/api/resolvers/titres-activites.ts
+++ b/src/api/resolvers/titres-activites.ts
@@ -164,7 +164,9 @@ const activiteModifier = async (
     }
 
     activite.utilisateurId = user.id
-    activite.dateSaisie = dateFormat(new Date(), 'yyyy-mm-dd')
+
+    const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
+    activite.dateSaisie = aujourdhui
 
     const fields = graphFieldsBuild(info)
 

--- a/src/business/processes/__mocks__/titres-phases-update-titres.ts
+++ b/src/business/processes/__mocks__/titres-phases-update-titres.ts
@@ -71,7 +71,7 @@ const titresUnePhaseMiseAJour = [
         phase: {
           titreDemarcheId: 'h-cx-courdemanges-1988-oct01',
           dateFin: '2500-01-01',
-          dateDebut: new Date('2300-01-01'),
+          dateDebut: '2300-01-01',
           statutId: 'val'
         },
         etapes: [

--- a/src/business/rules/titre-activites-build.ts
+++ b/src/business/rules/titre-activites-build.ts
@@ -24,9 +24,11 @@ const titreActiviteBuild = (
     'yyyy-mm-dd'
   )
 
+  const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
+
   // si la date de fin de l'activité n'est pas passée
   // on ne crée pas l'activité
-  if (periodeDateFin > dateFormat(new Date(), 'yyyy-mm-dd')) return null
+  if (periodeDateFin > aujourdhui) return null
 
   // si le statut du titre n'est pas "modification en instance"
   // - vérifie les dates de validité

--- a/src/business/rules/titre-phases-find.ts
+++ b/src/business/rules/titre-phases-find.ts
@@ -35,13 +35,15 @@ const titrePhasesFind = (
       // dateFin et dateDebut ne seront jamais `null`
       // car les démarches sont pré-filtrées
 
+      const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
+
       // si
       // - la date du jour est plus récente que la date de fin
       // le statut est valide
       // sinon,
       // - le statut est échu
       const statutId =
-        dateFormat(new Date(), 'yyyy-mm-dd') > dateFin ? 'ech' : 'val'
+        dateFin < aujourdhui ? 'ech' : 'val'
 
       titrePhases.push({
         titreDemarcheId: titreDemarche.id,

--- a/src/business/rules/titre-prop-etape-id-find.ts
+++ b/src/business/rules/titre-prop-etape-id-find.ts
@@ -1,6 +1,9 @@
 // retourne l'id de la dernière étape acceptée
 // de la dernière démarche acceptée
 // pour laquelle la propriété existe
+
+import * as dateFormat from 'dateformat'
+
 import { ITitreDemarche, ITitreEtape, TitreEtapeProp } from '../../types'
 import titreDemarchesAscSort from '../utils/titre-demarches-asc-sort'
 import titreEtapesDescSort from '../utils/titre-etapes-desc-sort'
@@ -11,9 +14,11 @@ const etapeAmodiataireFind = (
 ) => {
   const { dateFin } = titreEtape
 
+  const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
+
   // si la date de fin de l'étape est passée
   // l'amodiataire n'est plus valide
-  if (dateFin && new Date(dateFin) < new Date()) return false
+  if (dateFin && dateFin < aujourdhui) return false
 
   // sinon, si le titre a le statut modification en instance
   // l'amodiataire est encore valide (survie provisoire)

--- a/src/business/rules/titre-statut-id-find.ts
+++ b/src/business/rules/titre-statut-id-find.ts
@@ -37,8 +37,8 @@ const titreStatutIdFind = (titre: ITitre) => {
 
   // la date du jour est inférieure à la date d’échéance
   const dateFin = titreDateFinFind(titre.demarches)
-  const today = dateFormat(new Date(), 'yyyy-mm-dd')
-  if (dateFin && today < dateFin) {
+  const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
+  if (dateFin && aujourdhui < dateFin) {
     // le statut du titre est valide
     return 'val'
   }

--- a/src/business/utils/activite-type-annees-find.test.ts
+++ b/src/business/utils/activite-type-annees-find.test.ts
@@ -1,14 +1,16 @@
 import { IActiviteType } from '../../types'
+import * as dateFormat from 'dateformat'
 
 import activiteTypeAnneesFind from './activite-type-annees-find'
 
 describe('calcule les années que couvre une activité', () => {
   test("retourne un tableau d'années que couvre une activité", () => {
-    const anneeEnCours = new Date().getFullYear()
+      const anneeEnCours = new Date().getFullYear()
+      const aujourdhui = dateFormat(new Date(), 'yyyy-mm-dd')
 
     expect(
       activiteTypeAnneesFind(({
-        dateDebut: new Date()
+        dateDebut: aujourdhui
       } as unknown) as IActiviteType)
     ).toEqual([anneeEnCours])
   })


### PR DESCRIPTION
Sort ce bout de code :
```js
dateFormat(new Date(), 'yyyy-mm-dd')
```
dans des variables `aujourdhui` pour plus d'expressivité.

On peut imaginer un `aujourdhuiGet` dans `src/tools` vu que ça a l'air d'être un besoin récurent.