### PR TITLE
proposition de correction du type d'une etape

### DIFF
--- a/knex/migrations/20180522000002_titres_demarches_etapes.js
+++ b/knex/migrations/20180522000002_titres_demarches_etapes.js
@@ -2,7 +2,10 @@ exports.up = knex => {
   return knex.schema
     .createTable('titresDemarches', table => {
       table.string('id', 128).primary()
-      table.string('titreId', 128).notNullable().index()
+      table
+        .string('titreId', 128)
+        .notNullable()
+        .index()
       table
         .foreign('titreId')
         .references('titres.id')
@@ -21,6 +24,10 @@ exports.up = knex => {
         .defaultTo('ind')
       table.boolean('publicLecture').defaultTo(false)
       table.boolean('entreprisesLecture').defaultTo(false)
+      table
+        .string('titreTypeId', 3)
+        .notNullable()
+        .references('titresTypes.id')
       table.integer('ordre').defaultTo('0')
     })
     .createTable('titresDemarchesLiens', table => {
@@ -45,13 +52,19 @@ exports.up = knex => {
         .references('titresDemarches.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
-      table.string('statutId', 3).notNullable().references('phasesStatuts.id')
+      table
+        .string('statutId', 3)
+        .notNullable()
+        .references('phasesStatuts.id')
       table.string('dateDebut', 10)
       table.string('dateFin', 10)
     })
     .createTable('titresEtapes', table => {
       table.string('id', 128).primary()
-      table.string('titreDemarcheId', 128).notNullable().index()
+      table
+        .string('titreDemarcheId', 128)
+        .notNullable()
+        .index()
       table
         .foreign('titreDemarcheId')
         .references('titresDemarches.id')
@@ -67,6 +80,14 @@ exports.up = knex => {
         .notNullable()
         .index()
         .references('etapesStatuts.id')
+      table
+        .string('demarcheTypeId', 3)
+        .notNullable()
+        .references('demarchesTypes.id')
+      table
+        .string('titreTypeId', 3)
+        .notNullable()
+        .references('titresTypes.id')
       table.integer('ordre')
       table.string('date', 10).notNullable()
       table.string('dateDebut', 10)

--- a/src/database/models/titres-demarches.ts
+++ b/src/database/models/titres-demarches.ts
@@ -17,6 +17,7 @@ class TitresDemarches extends Model {
       typeId: { type: 'string', maxLength: 8 },
       statutId: { type: 'string', maxLength: 3 },
       ordre: { type: 'integer' }
+      titreTypeId: { type: 'string', maxLength: 8 }
     }
   }
 

--- a/src/database/models/titres-etapes.ts
+++ b/src/database/models/titres-etapes.ts
@@ -19,6 +19,8 @@ class TitresEtapes extends Model {
       date: { type: ['string', 'null'] },
       typeId: { type: 'string', maxLength: 3 },
       statutId: { type: 'string', maxLength: 3 },
+      demarcheTypeId: { type: 'string', maxLength: 3 },
+      titreTypeId: { type: 'string', maxLength: 3 },
       ordre: { type: 'integer' },
       dateDebut: { type: ['string', 'null'] },
       dateFin: { type: ['string', 'null'] },
@@ -30,10 +32,28 @@ class TitresEtapes extends Model {
 
   public static relationMappings = {
     type: {
-      relation: Model.BelongsToOneRelation,
+      relation: Model.ManyToManyRelation,
       modelClass: join(__dirname, 'etapes-types'),
       join: {
-        from: 'titresEtapes.typeId',
+        from: [
+          'titresEtapes.typeId',
+          'titresEtapes.demarcheTypeId',
+          'titresEtapes.titreTypeId'
+        ],
+        through: {
+          from: [
+            'titresTypes__demarchesTypes__etapesTypes.etapeTypeId',
+            'titresTypes__demarchesTypes__etapesTypes.demarcheTypeId',
+            'titresTypes__demarchesTypes__etapesTypes.titreTypeId'
+          ],
+          to: 'titresTypes__demarchesTypes__etapesTypes.etapeTypeId',
+          // permet de donner un alias spécial aux champs extra { alias: field }
+          extra: {
+            ordre: 'ordre',
+            titreTypeId: 'titreTypeId',
+            sectionsSpecifiques: 'sections'
+          }
+        },
         to: 'etapesTypes.id'
       }
     },
@@ -175,6 +195,10 @@ class TitresEtapes extends Model {
 
   $afterFind() {
     this.pays = paysFormat(this.communes || [])
+
+    if (this.type) {
+      this.type = this.type[0]
+    }
 
     return this
   }


### PR DESCRIPTION
En ajoutant le type de titre et de démarche à une étape, on peut requêter la table `TDE` depuis l'étape pour avoir son type.
Seul inconvénient, on doit faire un `through` pour arriver au modèle du type d'étape et c'est seulement possible avec une relation `ManyToMany`, d'où le hack avec le `afterGet`.