### PR TITLE
perf(db): ajoute des index pour les clefs étrangères

### DIFF
--- a/knex/migrations/20180521000001_domaines_types_statuts.js
+++ b/knex/migrations/20180521000001_domaines_types_statuts.js
@@ -17,11 +17,13 @@ exports.up = knex =>
       table.string('id', 3).primary().notNullable()
       table
         .string('domaineId', 1)
+        .index()
         .references('domaines.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('typeId', 3)
+        .index()
         .references('titresTypesTypes.id')
         .notNullable()
         .onDelete('CASCADE')

--- a/knex/migrations/20180521000002_demarches_etapes.js
+++ b/knex/migrations/20180521000002_demarches_etapes.js
@@ -16,11 +16,13 @@ exports.up = knex => {
     .createTable('titresTypes__demarchesTypes', table => {
       table
         .string('titreTypeId', 3)
+        .index()
         .references('titresTypes.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('demarcheTypeId', 3)
+        .index()
         .references('demarchesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
@@ -63,17 +65,20 @@ exports.up = knex => {
     .createTable('titresTypes__demarchesTypes__etapesTypes', table => {
       table
         .string('titreTypeId', 3)
+        .index()
         .references('titresTypes.id')
         .notNullable()
         .onDelete('CASCADE')
       table.integer('ordre')
       table
         .string('demarcheTypeId', 7)
+        .index()
         .references('demarchesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('etapeTypeId', 3)
+        .index()
         .references('etapesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
@@ -89,11 +94,13 @@ exports.up = knex => {
     .createTable('etapesTypes__etapesStatuts', table => {
       table
         .string('etapeTypeId', 7)
+        .index()
         .references('etapesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('etapeStatutId', 3)
+        .index()
         .references('etapesStatuts.id')
         .notNullable()
         .onDelete('CASCADE')

--- a/knex/migrations/20180521000003_unites.js
+++ b/knex/migrations/20180521000003_unites.js
@@ -14,7 +14,7 @@ exports.up = knex =>
       table.string('id', 5).primary()
       table.string('nom').notNullable()
       table.integer('ordre')
-      table.string('uniteId', 3).references('unites.id').notNullable()
+      table.string('uniteId', 3).index().references('unites.id').notNullable()
       table.string('zone')
       table.string('definitionProj4')
     })

--- a/knex/migrations/20180521000004_substances.js
+++ b/knex/migrations/20180521000004_substances.js
@@ -10,10 +10,15 @@ exports.up = knex => {
     .createTable('substancesLegales', table => {
       table.string('id').primary()
       table.string('nom').notNullable()
-      table.string('domaineId', 1).notNullable().references('domaines.id')
+      table
+        .string('domaineId', 1)
+        .notNullable()
+        .index()
+        .references('domaines.id')
       table.text('description')
       table
         .string('substanceLegaleCodeId')
+        .index()
         .references('substancesLegalesCodes.id')
         .notNullable()
     })
@@ -27,11 +32,13 @@ exports.up = knex => {
     .createTable('substances__substancesLegales', table => {
       table
         .string('substanceId')
+        .index()
         .references('substances.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('substanceLegaleId')
+        .index()
         .references('substancesLegales.id')
         .notNullable()
       table.primary(['substanceId', 'substanceLegaleId'])

--- a/knex/migrations/20180521000005_territoires.js
+++ b/knex/migrations/20180521000005_territoires.js
@@ -8,13 +8,13 @@ exports.up = knex => {
     .createTable('regions', table => {
       table.string('id', 2).primary()
       table.string('nom')
-      table.string('paysId', 3).notNullable().references('pays.id')
+      table.string('paysId', 3).notNullable().index().references('pays.id')
       table.string('cheflieuId', 5)
     })
     .createTable('departements', table => {
       table.string('id', 3).primary()
       table.string('nom').notNullable()
-      table.string('regionId', 2).notNullable().references('regions.id')
+      table.string('regionId', 2).notNullable().index().references('regions.id')
       table.string('cheflieuId', 5)
     })
     .createTable('communes', table => {
@@ -23,6 +23,7 @@ exports.up = knex => {
       table
         .string('departementId', 3)
         .notNullable()
+        .index()
         .references('departements.id')
       table.integer('surface')
     })

--- a/knex/migrations/20180521000006_calendrier.js
+++ b/knex/migrations/20180521000006_calendrier.js
@@ -8,18 +8,18 @@ exports.up = knex => {
     .createTable('annees', table => {
       table.integer('id', 1).primary()
       table.string('nom').notNullable()
-      table.string('frequenceId', 3).references('frequences.id')
+      table.string('frequenceId', 3).index().references('frequences.id')
     })
     .createTable('trimestres', table => {
       table.integer('id', 1).primary()
       table.string('nom').notNullable()
-      table.string('frequenceId', 3).references('frequences.id')
+      table.string('frequenceId', 3).index().references('frequences.id')
     })
     .createTable('mois', table => {
       table.integer('id', 2).primary()
       table.string('nom').notNullable()
-      table.string('frequenceId', 3).references('frequences.id')
-      table.integer('trimestreId', 1).references('trimestres.id')
+      table.string('frequenceId', 3).index().references('frequences.id')
+      table.integer('trimestreId', 1).index().references('trimestres.id')
     })
 }
 

--- a/knex/migrations/20180521000007_repertoire.js
+++ b/knex/migrations/20180521000007_repertoire.js
@@ -21,6 +21,7 @@ exports.up = knex =>
       table.string('id', 64).primary()
       table
         .string('entrepriseId', 64)
+        .index()
         .references('entreprises.id')
         .notNullable()
         .onDelete('CASCADE')
@@ -36,7 +37,11 @@ exports.up = knex =>
     })
     .createTable('administrations', table => {
       table.string('id', 64).primary()
-      table.string('typeId').references('administrationsTypes.id').notNullable()
+      table
+        .string('typeId')
+        .index()
+        .references('administrationsTypes.id')
+        .notNullable()
       table.string('nom').notNullable()
       table.string('abreviation', 255)
       table.string('service')
@@ -48,8 +53,8 @@ exports.up = knex =>
       table.string('codePostal')
       table.string('commune')
       table.string('cedex')
-      table.string('departementId').references('departements.id')
-      table.string('regionId').references('regions.id')
+      table.string('departementId').index().references('departements.id')
+      table.string('regionId').index().references('regions.id')
     })
     .createTable('permissions', table => {
       table.string('id', 12).primary()
@@ -66,6 +71,7 @@ exports.up = knex =>
       table.string('telephoneMobile')
       table
         .string('permissionId', 12)
+        .index()
         .references('permissions.id')
         .notNullable()
         .onDelete('CASCADE')
@@ -74,20 +80,24 @@ exports.up = knex =>
     .createTable('utilisateurs__entreprises', table => {
       table
         .string('utilisateurId', 64)
+        .index()
         .references('utilisateurs.id')
         .onDelete('CASCADE')
       table
         .string('entrepriseId', 64)
+        .index()
         .references('entreprises.id')
         .onDelete('CASCADE')
     })
     .createTable('utilisateurs__administrations', table => {
       table
         .string('utilisateurId', 64)
+        .index()
         .references('utilisateurs.id')
         .onDelete('CASCADE')
       table
         .string('administrationId', 64)
+        .index()
         .references('administrations.id')
         .onDelete('CASCADE')
         .onUpdate('CASCADE')

--- a/knex/migrations/20180522000001_titres.js
+++ b/knex/migrations/20180522000001_titres.js
@@ -2,10 +2,11 @@ exports.up = knex =>
   knex.schema.createTable('titres', table => {
     table.string('id', 128).primary()
     table.string('nom').notNullable()
-    table.string('typeId', 3).references('titresTypes.id').notNullable()
-    table.string('domaineId', 1).references('domaines.id').notNullable()
+    table.string('typeId', 3).index().references('titresTypes.id').notNullable()
+    table.string('domaineId', 1).index().references('domaines.id').notNullable()
     table
       .string('statutId', 3)
+      .index()
       .references('titresStatuts.id')
       .notNullable()
       .defaultTo('ind')

--- a/knex/migrations/20180522000002_titres_demarches_etapes.js
+++ b/knex/migrations/20180522000002_titres_demarches_etapes.js
@@ -2,31 +2,36 @@ exports.up = knex => {
   return knex.schema
     .createTable('titresDemarches', table => {
       table.string('id', 128).primary()
-      table.string('titreId', 128).notNullable()
+      table.string('titreId', 128).notNullable().index()
       table
         .foreign('titreId')
         .references('titres.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
-      table.string('typeId', 3).notNullable().references('demarchesTypes.id')
+      table
+        .string('typeId', 3)
+        .notNullable()
+        .index()
+        .references('demarchesTypes.id')
       table
         .string('statutId', 3)
         .notNullable()
+        .index()
         .references('demarchesStatuts.id')
         .defaultTo('ind')
       table.boolean('publicLecture').defaultTo(false)
       table.boolean('entreprisesLecture').defaultTo(false)
       table.integer('ordre').defaultTo('0')
-      table.string('annulationTitreDemarcheId', 128).references('id')
+      table.string('annulationTitreDemarcheId', 128).index().references('id')
     })
     .createTable('titresDemarchesLiens', table => {
-      table.string('enfantTitreDemarcheId', 128)
+      table.string('enfantTitreDemarcheId', 128).index()
       table
         .foreign('enfantTitreDemarcheId')
         .references('titresDemarches.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
-      table.string('parentTitreDemarcheId', 128)
+      table.string('parentTitreDemarcheId', 128).index()
       table
         .foreign('parentTitreDemarcheId')
         .references('titresDemarches.id')
@@ -47,14 +52,22 @@ exports.up = knex => {
     })
     .createTable('titresEtapes', table => {
       table.string('id', 128).primary()
-      table.string('titreDemarcheId', 128).notNullable()
+      table.string('titreDemarcheId', 128).notNullable().index()
       table
         .foreign('titreDemarcheId')
         .references('titresDemarches.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
-      table.string('typeId', 3).notNullable().references('etapesTypes.id')
-      table.string('statutId', 3).notNullable().references('etapesStatuts.id')
+      table
+        .string('typeId', 3)
+        .notNullable()
+        .index()
+        .references('etapesTypes.id')
+      table
+        .string('statutId', 3)
+        .notNullable()
+        .index()
+        .references('etapesStatuts.id')
       table.integer('ordre')
       table.string('date', 10).notNullable()
       table.string('dateDebut', 10)

--- a/knex/migrations/20180522000003_titres_etapes_substances_emprises.js
+++ b/knex/migrations/20180522000003_titres_etapes_substances_emprises.js
@@ -1,12 +1,16 @@
 exports.up = knex => {
   return knex.schema.createTable('titresSubstances', table => {
-    table.string('titreEtapeId', 128).notNullable()
+    table.string('titreEtapeId', 128).notNullable().index()
     table
       .foreign('titreEtapeId')
       .references('titresEtapes.id')
       .onUpdate('CASCADE')
       .onDelete('CASCADE')
-    table.string('substanceId', 4).references('substances.id').notNullable()
+    table
+      .string('substanceId', 4)
+      .index()
+      .references('substances.id')
+      .notNullable()
     table.boolean('connexe')
     table.integer('ordre')
     table.primary(['titreEtapeId', 'substanceId'])

--- a/knex/migrations/20180522000004_titres_etapes_utilisateurs_titulaires_amodiataires_administrations.js
+++ b/knex/migrations/20180522000004_titres_etapes_utilisateurs_titulaires_amodiataires_administrations.js
@@ -1,7 +1,7 @@
 exports.up = knex => {
   return knex.schema
     .createTable('titresTitulaires', table => {
-      table.string('titreEtapeId', 128).notNullable()
+      table.string('titreEtapeId', 128).notNullable().index()
       table
         .foreign('titreEtapeId')
         .references('titresEtapes.id')
@@ -9,6 +9,7 @@ exports.up = knex => {
         .onDelete('CASCADE')
       table
         .string('entrepriseId', 64)
+        .index()
         .references('entreprises.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
@@ -19,11 +20,13 @@ exports.up = knex => {
     .createTable('titresAmodiataires', table => {
       table
         .string('titreEtapeId', 128)
+        .index()
         .references('titresEtapes.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('entrepriseId', 64)
+        .index()
         .references('entreprises.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
@@ -33,7 +36,7 @@ exports.up = knex => {
     })
 
     .createTable('titresAdministrationsGestionnaires', table => {
-      table.string('titreId', 128).notNullable()
+      table.string('titreId', 128).notNullable().index()
       table
         .foreign('titreId')
         .references('titres.id')
@@ -41,6 +44,7 @@ exports.up = knex => {
         .onDelete('CASCADE')
       table
         .string('administrationId', 64)
+        .index()
         .references('administrations.id')
         .notNullable()
         .onUpdate('CASCADE')
@@ -49,7 +53,7 @@ exports.up = knex => {
       table.primary(['titreId', 'administrationId'])
     })
     .createTable('titresAdministrationsLocales', table => {
-      table.string('titreEtapeId', 128).notNullable()
+      table.string('titreEtapeId', 128).notNullable().index()
       table
         .foreign('titreEtapeId')
         .references('titresEtapes.id')
@@ -57,6 +61,7 @@ exports.up = knex => {
         .onDelete('CASCADE')
       table
         .string('administrationId', 64)
+        .index()
         .references('administrations.id')
         .notNullable()
         .onUpdate('CASCADE')

--- a/knex/migrations/20180522000005_titres_etapes_points.js
+++ b/knex/migrations/20180522000005_titres_etapes_points.js
@@ -2,7 +2,7 @@ exports.up = knex => {
   return knex.schema
     .createTable('titresPoints', table => {
       table.string('id').primary()
-      table.string('titreEtapeId', 128).notNullable()
+      table.string('titreEtapeId', 128).notNullable().index()
       table
         .foreign('titreEtapeId')
         .references('titresEtapes.id')
@@ -22,6 +22,7 @@ exports.up = knex => {
       table.string('id').primary()
       table
         .string('titrePointId')
+        .index()
         .references('titresPoints.id')
         .onDelete('CASCADE')
       table.string('geoSystemeId', 5).notNullable()

--- a/knex/migrations/20180522000006_titres_etapes_communes.js
+++ b/knex/migrations/20180522000006_titres_etapes_communes.js
@@ -1,12 +1,12 @@
 exports.up = knex =>
   knex.schema.createTable('titresCommunes', table => {
-    table.string('titreEtapeId', 128).notNullable()
+    table.string('titreEtapeId', 128).notNullable().index()
     table
       .foreign('titreEtapeId')
       .references('titresEtapes.id')
       .onUpdate('CASCADE')
       .onDelete('CASCADE')
-    table.string('communeId', 8).notNullable().references('communes.id')
+    table.string('communeId', 8).notNullable().index().references('communes.id')
     table.integer('surface')
     table.primary(['titreEtapeId', 'communeId'])
   })

--- a/knex/migrations/20180522000009_titres_references.js
+++ b/knex/migrations/20180522000009_titres_references.js
@@ -1,12 +1,16 @@
 exports.up = knex => {
   return knex.schema.createTable('titresReferences', table => {
-    table.string('titreId', 128).notNullable()
+    table.string('titreId', 128).notNullable().index()
     table
       .foreign('titreId')
       .references('titres.id')
       .onUpdate('CASCADE')
       .onDelete('CASCADE')
-    table.string('typeId', 3).references('referencesTypes.id').notNullable()
+    table
+      .string('typeId', 3)
+      .index()
+      .references('referencesTypes.id')
+      .notNullable()
     table.string('nom')
     table.primary(['titreId', 'typeId', 'nom'])
   })

--- a/knex/migrations/20181106000001_metas_activites.js
+++ b/knex/migrations/20181106000001_metas_activites.js
@@ -4,22 +4,32 @@ exports.up = knex =>
       table.string('id', 3).primary()
       table.string('nom').notNullable()
       table.specificType('sections', 'jsonb[]').notNullable()
-      table.string('frequenceId', 3).notNullable().references('frequences.id')
+      table
+        .string('frequenceId', 3)
+        .notNullable()
+        .index()
+        .references('frequences.id')
       table.string('dateDebut').notNullable()
       table.integer('delaiMois')
     })
     .createTable('titresTypes__activitesTypes', table => {
-      table.string('titreTypeId', 3).references('titresTypes.id').notNullable()
+      table
+        .string('titreTypeId', 3)
+        .index()
+        .references('titresTypes.id')
+        .notNullable()
       table
         .string('activiteTypeId', 3)
+        .index()
         .references('activitesTypes.id')
         .notNullable()
       table.primary(['titreTypeId', 'activiteTypeId'])
     })
     .createTable('activitesTypes__pays', table => {
-      table.string('paysId', 3).notNullable().references('pays.id')
+      table.string('paysId', 3).notNullable().index().references('pays.id')
       table
         .string('activiteTypeId', 3)
+        .index()
         .references('activitesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
@@ -28,12 +38,14 @@ exports.up = knex =>
     .createTable('activitesTypes__administrations', table => {
       table
         .string('activiteTypeId', 3)
+        .index()
         .references('activitesTypes.id')
         .notNullable()
         .onDelete('CASCADE')
       table
         .string('administrationId', 64)
         .notNullable()
+        .index()
         .references('administrations.id')
         .onDelete('CASCADE')
       table.primary(['administrationId', 'activiteTypeId'])
@@ -41,10 +53,12 @@ exports.up = knex =>
     .createTable('activitesTypes__documentsTypes', table => {
       table
         .string('activiteTypeId', 3)
+        .index()
         .references('activitesTypes.id')
         .notNullable()
       table
         .string('documentTypeId', 3)
+        .index()
         .references('documentsTypes.id')
         .notNullable()
       table.primary(['activiteTypeId', 'documentTypeId'])

--- a/knex/migrations/20181106000002_titres_activites.js
+++ b/knex/migrations/20181106000002_titres_activites.js
@@ -1,13 +1,25 @@
 exports.up = knex =>
   knex.schema.createTable('titresActivites', table => {
     table.string('id').primary()
-    table.string('titreId', 128).references('titres.id').onDelete('CASCADE')
-    table.string('utilisateurId', 128).references('utilisateurs.id')
+    table
+      .string('titreId', 128)
+      .index()
+      .references('titres.id')
+      .onDelete('CASCADE')
+    table.string('utilisateurId', 128).index().references('utilisateurs.id')
     table.string('date', 10)
     table.string('dateSaisie', 10)
     table.jsonb('contenu')
-    table.string('typeId', 3).references('activitesTypes.id').notNullable()
-    table.string('statutId', 3).references('activitesStatuts.id').notNullable()
+    table
+      .string('typeId', 3)
+      .index()
+      .references('activitesTypes.id')
+      .notNullable()
+    table
+      .string('statutId', 3)
+      .index()
+      .references('activitesStatuts.id')
+      .notNullable()
     table.integer('annee', 4)
     table.integer('frequencePeriodeId', 2)
   })

--- a/knex/migrations/20181106000003_autorisations.js
+++ b/knex/migrations/20181106000003_autorisations.js
@@ -1,8 +1,16 @@
 exports.up = knex =>
   knex.schema
     .createTable('a__titresTypes__titresStatuts', table => {
-      table.string('titreTypeId').references('titresTypes.id').notNullable()
-      table.string('titreStatutId').references('titresStatuts.id').notNullable()
+      table
+        .string('titreTypeId')
+        .index()
+        .references('titresTypes.id')
+        .notNullable()
+      table
+        .string('titreStatutId')
+        .index()
+        .references('titresStatuts.id')
+        .notNullable()
       table.boolean('publicLecture').notNullable()
       table.primary(['titreTypeId', 'titreStatutId'])
     })
@@ -15,11 +23,16 @@ exports.up = knex =>
     .createTable('a__titresTypes__administrations', table => {
       table
         .string('administrationId')
+        .index()
         .references('administrations.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
         .notNullable()
-      table.string('titreTypeId').references('titresTypes.id').notNullable()
+      table
+        .string('titreTypeId')
+        .index()
+        .references('titresTypes.id')
+        .notNullable()
       table.boolean('gestionnaire').notNullable()
       table.boolean('associee').notNullable()
       table.primary(['administrationId', 'titreTypeId'])
@@ -27,12 +40,21 @@ exports.up = knex =>
     .createTable('r__titresTypes__titresStatuts__administrations', table => {
       table
         .string('administrationId')
+        .index()
         .references('administrations.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
         .notNullable()
-      table.string('titreTypeId').references('titresTypes.id').notNullable()
-      table.string('titreStatutId').references('titresStatuts.id').notNullable()
+      table
+        .string('titreTypeId')
+        .index()
+        .references('titresTypes.id')
+        .notNullable()
+      table
+        .string('titreStatutId')
+        .index()
+        .references('titresStatuts.id')
+        .notNullable()
       table.boolean('titresModificationInterdit').notNullable()
       table.boolean('demarchesModificationInterdit').notNullable()
       table.boolean('etapesModificationInterdit').notNullable()
@@ -41,12 +63,21 @@ exports.up = knex =>
     .createTable('r__titresTypes__etapesTypes__administrations', table => {
       table
         .string('administrationId')
+        .index()
         .references('administrations.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
         .notNullable()
-      table.string('titreTypeId').references('titresTypes.id').notNullable()
-      table.string('etapeTypeId').references('etapesTypes.id').notNullable()
+      table
+        .string('titreTypeId')
+        .index()
+        .references('titresTypes.id')
+        .notNullable()
+      table
+        .string('etapeTypeId')
+        .index()
+        .references('etapesTypes.id')
+        .notNullable()
       table.boolean('lectureInterdit').notNullable()
       table.boolean('creationInterdit').notNullable()
       table.boolean('modificationInterdit').notNullable()

--- a/knex/migrations/20181106000004_documents.js
+++ b/knex/migrations/20181106000004_documents.js
@@ -2,22 +2,26 @@ exports.up = knex =>
   knex.schema
     .createTable('documents', table => {
       table.string('id').primary()
-      table.string('typeId', 3).references('documentsTypes.id').notNullable()
+      table
+        .string('typeId', 3)
+        .index()
+        .references('documentsTypes.id')
+        .notNullable()
       table.string('date', 10).notNullable()
-      table.string('entrepriseId', 64)
+      table.string('entrepriseId', 64).index()
       table
         .foreign('entrepriseId')
         .references('entreprises.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
-      table.string('titreEtapeId', 128)
+      table.string('titreEtapeId', 128).index()
       table
         .foreign('titreEtapeId')
         .references('titresEtapes.id')
         .onUpdate('CASCADE')
         .onDelete('CASCADE')
       table.string('description', 1024)
-      table.string('titreActiviteId', 128)
+      table.string('titreActiviteId', 128).index()
       table
         .foreign('titreActiviteId')
         .references('titresActivites.id')
@@ -33,7 +37,7 @@ exports.up = knex =>
       table.boolean('entreprises_lecture')
     })
     .createTable('titresEtapesJustificatifs', table => {
-      table.string('titreEtapeId', 128)
+      table.string('titreEtapeId', 128).index()
       table
         .foreign('titreEtapeId')
         .references('titresEtapes.id')
@@ -41,6 +45,7 @@ exports.up = knex =>
         .onDelete('CASCADE')
       table
         .string('documentId')
+        .index()
         .references('documents.id')
         .notNullable()
         .onUpdate('CASCADE')


### PR DESCRIPTION
Suite à l'étude des temps d'exécution des requêtes SQL, nous avons
remarqué qu'une requête était particulièrement lente sur la table
titres_points et la jointure sur titre_etape_id.

Avec la création de l'index, le temps de traitement passe de 220 ms
à 23 ms sur la base de prod.

La majorité des tables contiennent moins de 7k enregistrements sauf :
- titres_points_references: 19k
- titres_points: 18k
- titres_communes: 14k
- titres_etapes: 11k

Nous pourrions uniquement créer des index pour ces tables toutefois,
il nous semble pertinent de systématiquement utiliser des
index sur le FK dans la mesure où :
- l'espace de stockage n'est pas une contrainte
- le nombre d'ajout/suppression est faible.

Des frameworks tels que Django utilise ce comportement par défaut.

L'impact sur la réponse du serveur à la requête de la page d'accueil est
d'environ 270 ms (950 ms à 680 ms).

PS : la création de l'index GIST est dans la PR associée au périmètre.