### PR TITLE
fix(titres): corrige la requête de tri par nom

### DIFF
--- a/src/database/queries/titres.ts
+++ b/src/database/queries/titres.ts
@@ -116,10 +116,10 @@ const titreFromIdGet = async (
 }
 
 const titresColonnes = {
-  nom: { id: 'nom' },
-  domaine: { id: 'domaineId' },
+  nom: { id: 'nom', groupBy: ['titres.nom'] },
+  domaine: { id: 'domaineId', groupBy: ['titres.domaineId'] },
   type: { id: 'type:type.nom', relation: 'type.type' },
-  statut: { id: 'statutId' },
+  statut: { id: 'statutId', groupBy: ['titres.statutId'] },
   activites: {
     id: 'activites',
     groupBy: []


### PR DESCRIPTION
```
select "titres".*, true as "modification", true as "suppression", "activites_count_join"."activites_absentes", "activites_count_join"."activites_en_construction", "activites_count_join"."activites_deposees" from "titres" left join (select "activites_count"."titre_id", count("activites_count"."statut_id") FILTER (WHERE "activites_count"."statut_id" = $1) as "activites_absentes", count("activites_count"."statut_id") FILTER (WHERE "activites_count"."statut_id" = $2) as "activites_en_construction", count("activites_count"."statut_id") FILTER (WHERE "activites_count"."statut_id" = $3) as "activites_deposees" from "titres_activites" as "activites_count" group by "activites_count"."titre_id") as "activites_count_join" on "activites_count_join"."titre_id" = "titres"."id" left join "titres_references" as "references" on "references"."titre_id" = "titres"."id" left join "references_types" as "references:type" on "references:type"."id" = "references"."type_id" where (lower("references"."nom") like $4 or lower("references:type"."nom") like $5 or lower("references"."nom") like $6 or lower("references:type"."nom") like $7 or lower("references"."nom") like $8 or lower("references:type"."nom") like $9) group by "titres"."id", "activites_absentes", "activites_en_construction", "activites_deposees", "titres"."id", "nom" having (count(*) filter (where lower("references"."nom") like $10 or lower("references:type"."nom") like $11) > 0) and (count(*) filter (where lower("references"."nom") like $12 or lower("references:type"."nom") like $13) > 0) and (count(*) filter (where lower("references"."nom") like $14 or lower("references:type"."nom") like $15) > 0) order by "nom" asc limit $16 - column reference "nom" is ambiguous
```