### PR TITLE
fix(arm): corrige l'arbre d'instruction de l'octroi d'ARM

### DIFF
--- a/src/business/definitions/titres-types-etapes-types-restrictions/arm/oct.ts
+++ b/src/business/definitions/titres-types-etapes-types-restrictions/arm/oct.ts
@@ -40,13 +40,15 @@ export default [
   },
 
   // titres mécanisés
-  {
-    condition: {
-      titre: { contenu: { arm: { mecanise: true } } },
-      etape: { typeId: 'mcp' }
-    },
-    obligatoireApres: [{ typeId: 'rde' }]
-  },
+
+  // TODO pour cette étape la condition porte sur le franchissement d'un cours d'eau ou non, elle n'est pas sur la mécanisation.
+  // {
+  //   condition: {
+  //     titre: { contenu: { arm: { mecanise: true } } },
+  //     etape: { typeId: 'mcp' }
+  //   },
+  //   obligatoireApres: [{ typeId: 'rde' }]
+  // },
   {
     condition: {
       titre: { contenu: { arm: { mecanise: true } } },


### PR DESCRIPTION
le récépissé de déclaration loi sur l'eau est obligatoire seulement si il y a un franchissement de
cours d'eau et non sur la mécanisation