### PR TITLE
fix(titre): corrige la condition de création d'un nouveau titre

### DIFF
--- a/src/database/queries/permissions/metas.ts
+++ b/src/database/queries/permissions/metas.ts
@@ -125,7 +125,7 @@ const titresTypesPermissionsQueryBuild = (
   if (permissionCheck(user?.permissionId, ['super'])) {
     q.select(raw('true').as('titresCreation'))
   } else if (
-    permissionCheck(user?.permissionId, ['admin', 'editeur', 'lecteur']) &&
+    permissionCheck(user?.permissionId, ['admin']) &&
     user?.administrations?.length
   ) {
     q.select(


### PR DESCRIPTION
un utilisateur éditeur ou lecteur ne doit pas voir le bouton de création de titre, car il ne peut
pas créer un titre