### PR TITLE
perf(matomo): ajoute un cache sur les appels Matomo

### DIFF
--- a/src/business/daily.ts
+++ b/src/business/daily.ts
@@ -30,6 +30,7 @@ import titresStatutIdsUpdate from './processes/titres-statut-ids-update'
 import titresTravauxOrdreUpdate from './processes/titres-travaux-ordre-update'
 import { titresTravauxGet } from '../database/queries/titres-travaux'
 import titresTravauxEtapesOrdreUpdate from './processes/titres-travaux-etapes-ordre-update'
+import { matomoCacheInit } from '../tools/api-matomo'
 
 const run = async () => {
   try {
@@ -345,6 +346,10 @@ const run = async () => {
 
     // met à jour l'id dans le titre par effet de bord
     const titresUpdatedIndex = await titresIdsUpdate(titres)
+
+    console.info()
+    console.info('rafraichissement du cache Matomo…')
+    await matomoCacheInit()
 
     console.info()
     console.info('tâches quotidiennes exécutées:')

--- a/src/tools/api-matomo/index.ts
+++ b/src/tools/api-matomo/index.ts
@@ -26,6 +26,16 @@ interface IMatomoResult {
   }
 }
 
+let matomoCache: {
+  recherches: { mois: string; quantite: string }[]
+  titresModifies: { mois: string; quantite: number }[]
+  actions: string
+  sessionDuree: string
+  telechargements: string
+  signalements: number
+  reutilisations: number
+}
+
 const matomoMainDataGet = async (duree: number) => {
   // Datas de la page 'Récapitulatif' des visites dans matomo
   // url
@@ -183,7 +193,7 @@ const titresModifiesCountGet = async (duree: number) => {
   )
 }
 
-const matomoData = async () => {
+const matomoCacheInit = async () => {
   // nombre de mois pour lesquels on souhaite des stats
   const duree = 12
 
@@ -208,7 +218,7 @@ const matomoData = async () => {
 
   const titresModifies = matomoResults[3]
 
-  return {
+  matomoCache = {
     recherches,
     titresModifies,
     actions,
@@ -217,6 +227,14 @@ const matomoData = async () => {
     signalements,
     reutilisations
   }
+}
+
+const matomoData = async () => {
+  if (!matomoCache) {
+    await matomoCacheInit()
+  }
+
+  return matomoCache
 }
 
 const timeFormat = (time: string) => {
@@ -242,4 +260,4 @@ const getPath = (
   return `${process.env.API_MATOMO_URL}/index.php?expanded=1${_params}&filter_limit=-1&format=JSON&idSite=${process.env.API_MATOMO_ID}&method=${method}&module=API&period=${period}&token_auth=${process.env.API_MATOMO_TOKEN}`
 }
 
-export { matomoData }
+export { matomoData, matomoCacheInit }


### PR DESCRIPTION
J’ai mis un cache uniquement sur les appels Matomo qui est mis à jour lors du daily (je ne pense pas que plus souvent soit utiles).
Je n’ai pas mis le reste volontairement en cache, car j’ai peur que des utilisateurs testent la pertinence des autres infos.