### PR TITLE
refactor(api): gère les permissions des démarches et des étapes en SQL

### DIFF
--- a/src/api/_permissions/titre-edition.ts
+++ b/src/api/_permissions/titre-edition.ts
@@ -1,129 +1,63 @@
 import { IUtilisateur } from '../../types'
 
-import { autorisations, restrictions } from '../../database/cache/autorisations'
-
 import { permissionCheck } from '../../tools/permission'
 import { titresModificationQueryBuild } from '../../database/queries/permissions/titres'
-
-type TypeName =
-  | 'titresModificationInterdit'
-  | 'demarchesModificationInterdit'
-  | 'etapesModificationInterdit'
-type ModeName = 'creationInterdit' | 'modificationInterdit'
+import { etapesTypesModificationQueryBuild } from '../../database/queries/permissions/metas'
 
 type EditionType = 'titres' | 'demarches' | 'etapes'
 type EditionMode = 'creation' | 'modification'
 
-const titreTypePermissionAdministrationIdCheck = (
-  administrationId: string,
-  titreTypeId: string,
-  titreMode: EditionMode
-) =>
-  autorisations.titresTypesAdministrations.some(
-    tta =>
-      administrationId === tta.administrationId &&
-      tta.titreTypeId === titreTypeId &&
-      // seule une administration gestionnaire peut créer un titre de ce type
-      (titreMode === 'creation' ? tta.gestionnaire : true)
-  )
+// TODO à bouger dans src/database/queries/permissions/metas.ts
 
-const titreTypeStatutPermissionAdministrationCheck = (
-  administrationId: string,
-  titreTypeId: string,
-  titreStatutId: string,
-  type: EditionType,
-  titreMode: EditionMode
-) =>
-  // vérifie que le type de titre est éditable par l'administration
-  titreTypePermissionAdministrationIdCheck(
-    administrationId,
-    titreTypeId,
-    titreMode
-  ) &&
-  // vérifie que l'administration n'a pas de restriction
-  // sur le type donné au statut donné
-  !restrictions.titresTypesTitresStatutsAdministrations.some(
-    restriction =>
-      restriction.administrationId === administrationId &&
-      restriction.titreTypeId === titreTypeId &&
-      restriction.titreStatutId === titreStatutId &&
-      restriction[`${type}ModificationInterdit` as TypeName]
-  )
-
-const titreEtapePermissionAdministrationCheck = (
-  administrationId: string,
-  titreTypeId: string,
-  titreStatutId: string,
-  etapeTypeId: string,
-  etapeMode: EditionMode
-) =>
-  // vérifie que le type de titre est éditable par l'administration
-  titreTypePermissionAdministrationIdCheck(
-    administrationId,
-    titreTypeId,
-    'modification'
-  ) &&
-  // vérifie que l'administration a les droits d'édition
-  // sur les étapes du titre au statut donné
-  titreTypeStatutPermissionAdministrationCheck(
-    administrationId,
-    titreTypeId,
-    titreStatutId,
-    'etapes',
-    'modification'
-  ) &&
-  // vérifie que l'administration n'a pas de restriction
-  // sur le type d'étape pour le titre au mode d'édition donné
-  !restrictions.titresTypesEtapesTypesAdministrations.some(
-    restriction =>
-      restriction.administrationId === administrationId &&
-      restriction.titreTypeId === titreTypeId &&
-      restriction.etapeTypeId === etapeTypeId &&
-      restriction[`${etapeMode}Interdit` as ModeName]
-  )
-
-const titreDemarchePermissionAdministrationsCheck = async (
+/**
+ * Vérifie que l'administration a les droits de modification sur le titre/démarche/étape
+ * du type de titre au statut donné
+ * @param user - utilisateur
+ * @param titreTypeId - type du titre
+ * @param titreStatutId - statut du titre
+ * @param type - type de modification souhaitée
+ */
+const titreTypeStatutPermissionAdministrationCheck = async (
   user: IUtilisateur,
   titreTypeId: string,
-  titreStatutId: string
+  titreStatutId: string,
+  type: EditionType
 ) => {
   const demarchesModificationAutorisation = await titresModificationQueryBuild(
     user.administrations!,
-    'demarches'
+    type
   )
     .andWhereRaw('?? = ?', ['titresModification.typeId', titreTypeId])
     .andWhereRaw('?? = ?', ['titresModification.statutId', titreStatutId])
-    .first()
 
   return (
     user &&
     (permissionCheck(user.permissionId, ['super']) ||
-      demarchesModificationAutorisation)
+      demarchesModificationAutorisation.length)
   )
 }
 
-const titreEtapePermissionAdministrationsCheck = (
+const titreEtapePermissionAdministrationsCheck = async (
   user: IUtilisateur | undefined,
-  titreTypeId: string,
-  titreStatutId: string,
+  titreId: string,
   etapeTypeId: string,
   etapeMode: EditionMode
 ) =>
   user &&
   (permissionCheck(user?.permissionId, ['super']) ||
-    user.administrations!.some(administration =>
-      // vérifie qu'au moins une administration a les droits d'édition
-      // sur le type de démarche au statut donné
-      titreEtapePermissionAdministrationCheck(
-        administration.id,
-        titreTypeId,
-        titreStatutId,
-        etapeTypeId,
-        etapeMode
+    // vérifie que l'administration a les droits d'édition
+    // sur les étapes du titre au statut donné
+    (
+      await etapesTypesModificationQueryBuild(
+        user.administrations!,
+        etapeMode === 'modification'
       )
-    ))
+        .whereRaw('?? = ?', ['titresModification.id', titreId])
+        .whereRaw('?? = ?', ['t_d_e.etapeTypeId', etapeTypeId])
+        .groupBy('titresModification.typeId')
+    ).length)
 
 export {
-  titreDemarchePermissionAdministrationsCheck,
+  titreTypeStatutPermissionAdministrationCheck,
   titreEtapePermissionAdministrationsCheck
 }

--- a/src/api/graphql/resolvers/documents.ts
+++ b/src/api/graphql/resolvers/documents.ts
@@ -177,14 +177,14 @@ const documentPermisssionsCheck = async (
     )
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreEtapePermissionAdministrationsCheck(
-        user,
-        titre.id,
-        etape.typeId,
-        'modification'
-      ))
-    ) {
+    const titreEtapePermission = await titreEtapePermissionAdministrationsCheck(
+      user,
+      titre.id,
+      etape.typeId,
+      'modification'
+    )
+
+    if (!titreEtapePermission) {
       throw new Error("droits insuffisants pour modifier ce document d'étape")
     }
   } else if (document.entrepriseId) {

--- a/src/api/graphql/resolvers/documents.ts
+++ b/src/api/graphql/resolvers/documents.ts
@@ -178,13 +178,12 @@ const documentPermisssionsCheck = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !titreEtapePermissionAdministrationsCheck(
+      !(await titreEtapePermissionAdministrationsCheck(
         user,
-        titre.typeId,
-        titre.statutId!,
+        titre.id,
         etape.typeId,
         'modification'
-      )
+      ))
     ) {
       throw new Error("droits insuffisants pour modifier ce document d'étape")
     }

--- a/src/api/graphql/resolvers/metas.ts
+++ b/src/api/graphql/resolvers/metas.ts
@@ -147,6 +147,7 @@ const statuts = async (_: never, context: IToken) => {
     let statuts = await titresStatutsGet()
 
     if (!context.user) {
+      // TODO à faire directement en SQL pour supprimer le cache autorisations
       statuts = statuts.filter(statut =>
         autorisations.statutsIds.includes(statut.id)
       )

--- a/src/api/graphql/resolvers/titres-demarches.ts
+++ b/src/api/graphql/resolvers/titres-demarches.ts
@@ -167,9 +167,7 @@ const demarcheCreer = async (
 
     const demarcheCreated = await titreDemarcheCreate(
       demarche,
-      {
-        fields: { id: {} }
-      },
+      { fields: { id: {} } },
       user?.id
     )
 
@@ -220,9 +218,7 @@ const demarcheModifier = async (
     const demarcheUpdated = await titreDemarcheUpdate(
       demarche.id,
       demarche,
-      {
-        fields: { id: {} }
-      },
+      { fields: { id: {} } },
       user.id,
       titre
     )

--- a/src/api/graphql/resolvers/titres-demarches.ts
+++ b/src/api/graphql/resolvers/titres-demarches.ts
@@ -11,7 +11,6 @@ import { debug } from '../../../config/index'
 import fieldsBuild from './_fields-build'
 
 import { permissionCheck } from '../../../tools/permission'
-import { titreDemarchePermissionAdministrationsCheck } from '../../_permissions/titre-edition'
 
 import { titreEtapesOrActivitesFichiersDelete } from './_titre-document'
 
@@ -166,43 +165,22 @@ const demarcheCreer = async (
   try {
     const user = context.user && (await userGet(context.user.id))
 
-    if (!user || !permissionCheck(user?.permissionId, ['super', 'admin'])) {
-      throw new Error('droits insuffisants')
-    }
-
-    if (permissionCheck(user?.permissionId, ['admin'])) {
-      const titre = await titreGet(demarche.titreId, {}, user.id)
-      if (!titre) throw new Error("le titre n'existe pas")
-
-      if (
-        !titreDemarchePermissionAdministrationsCheck(
-          user,
-          titre.typeId,
-          titre.statutId!
-        )
-      ) {
-        throw new Error('droits insuffisants pour créer cette démarche')
-      }
-    }
-
-    const rulesErrors = await titreDemarcheUpdationValidate(demarche)
-
-    if (rulesErrors.length) {
-      throw new Error(rulesErrors.join(', '))
-    }
-
-    const demarcheUpdated = await titreDemarcheCreate(demarche, {
-      fields: { id: {} }
-    })
+    const demarcheCreated = await titreDemarcheCreate(
+      demarche,
+      {
+        fields: { id: {} }
+      },
+      user?.id
+    )
 
     const titreUpdatedId = await titreDemarcheUpdateTask(
-      demarcheUpdated.id,
-      demarcheUpdated.titreId
+      demarcheCreated.id,
+      demarcheCreated.titreId
     )
 
     const fields = fieldsBuild(info)
 
-    const titreUpdated = await titreGet(titreUpdatedId, { fields }, user.id)
+    const titreUpdated = await titreGet(titreUpdatedId, { fields }, user?.id)
 
     return titreUpdated && titreFormat(user, titreUpdated)
   } catch (e) {
@@ -231,20 +209,7 @@ const demarcheModifier = async (
       { fields: { id: {} } },
       user.id
     )
-
     if (!titre) throw new Error("le titre n'existe pas")
-
-    if (permissionCheck(user?.permissionId, ['admin'])) {
-      if (
-        !titreDemarchePermissionAdministrationsCheck(
-          user,
-          titre.typeId,
-          titre.statutId!
-        )
-      ) {
-        throw new Error('droits insuffisants pour modifier cette démarche')
-      }
-    }
 
     const rulesErrors = await titreDemarcheUpdationValidate(demarche)
 
@@ -252,9 +217,15 @@ const demarcheModifier = async (
       throw new Error(rulesErrors.join(', '))
     }
 
-    const demarcheUpdated = await titreDemarcheUpdate(demarche.id, demarche, {
-      fields: { id: {} }
-    })
+    const demarcheUpdated = await titreDemarcheUpdate(
+      demarche.id,
+      demarche,
+      {
+        fields: { id: {} }
+      },
+      user.id,
+      titre
+    )
 
     const titreUpdatedId = await titreDemarcheUpdateTask(
       demarcheUpdated.id,
@@ -286,8 +257,6 @@ const demarcheSupprimer = async (
     if (!user || !permissionCheck(user?.permissionId, ['super'])) {
       throw new Error('droits insuffisants')
     }
-
-    // TODO: ajouter une validation ?
 
     const demarcheOld = await titreDemarcheGet(
       id,

--- a/src/api/graphql/resolvers/titres-etapes.ts
+++ b/src/api/graphql/resolvers/titres-etapes.ts
@@ -28,6 +28,7 @@ import titreEtapeUpdationValidate from '../../../business/titre-etape-updation-v
 import { GraphQLResolveInfo } from 'graphql'
 import fieldsBuild from './_fields-build'
 
+// TODO à refactorer, c’est un copier/coller de etapeModifier
 const etapeCreer = async (
   { etape }: { etape: ITitreEtape },
   context: IToken,
@@ -62,13 +63,12 @@ const etapeCreer = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !titreEtapePermissionAdministrationsCheck(
+      !(await titreEtapePermissionAdministrationsCheck(
         user,
-        titre.typeId,
-        titre.statutId!,
+        titre.id,
         etape.typeId,
         'creation'
-      )
+      ))
     ) {
       throw new Error('droits insuffisants pour créer cette étape')
     }
@@ -145,13 +145,12 @@ const etapeModifier = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !titreEtapePermissionAdministrationsCheck(
+      !(await titreEtapePermissionAdministrationsCheck(
         user,
-        titre.typeId,
-        titre.statutId!,
+        titre.id,
         etape.typeId,
         'modification'
-      )
+      ))
     ) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }
@@ -277,13 +276,12 @@ const etapeJustificatifsAssocier = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !titreEtapePermissionAdministrationsCheck(
+      !(await titreEtapePermissionAdministrationsCheck(
         user,
-        titre.typeId,
-        titre.statutId!,
+        titre.id,
         etape.typeId,
         'modification'
-      )
+      ))
     ) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }
@@ -357,13 +355,12 @@ const etapeJustificatifDissocier = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !titreEtapePermissionAdministrationsCheck(
+      !(await titreEtapePermissionAdministrationsCheck(
         user,
-        titre.typeId,
-        titre.statutId!,
+        titre.id,
         etape.typeId,
         'modification'
-      )
+      ))
     ) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }

--- a/src/api/graphql/resolvers/titres-etapes.ts
+++ b/src/api/graphql/resolvers/titres-etapes.ts
@@ -62,14 +62,14 @@ const etapeCreer = async (
 
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreEtapePermissionAdministrationsCheck(
-        user,
-        titre.id,
-        etape.typeId,
-        'creation'
-      ))
-    ) {
+    const titreEtapePermission = await titreEtapePermissionAdministrationsCheck(
+      user,
+      titre.id,
+      etape.typeId,
+      'creation'
+    )
+
+    if (!titreEtapePermission) {
       throw new Error('droits insuffisants pour créer cette étape')
     }
 
@@ -84,6 +84,7 @@ const etapeCreer = async (
         demarche,
         titre
       )
+
       if (rulesErrors.length) {
         throw new Error(rulesErrors.join(', '))
       }
@@ -144,14 +145,14 @@ const etapeModifier = async (
     )
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreEtapePermissionAdministrationsCheck(
-        user,
-        titre.id,
-        etape.typeId,
-        'modification'
-      ))
-    ) {
+    const titreEtapePermission = await titreEtapePermissionAdministrationsCheck(
+      user,
+      titre.id,
+      etape.typeId,
+      'modification'
+    )
+
+    if (!titreEtapePermission) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }
 
@@ -275,14 +276,14 @@ const etapeJustificatifsAssocier = async (
     )
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreEtapePermissionAdministrationsCheck(
-        user,
-        titre.id,
-        etape.typeId,
-        'modification'
-      ))
-    ) {
+    const titreEtapePermission = await titreEtapePermissionAdministrationsCheck(
+      user,
+      titre.id,
+      etape.typeId,
+      'modification'
+    )
+
+    if (!titreEtapePermission) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }
 
@@ -354,14 +355,14 @@ const etapeJustificatifDissocier = async (
 
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreEtapePermissionAdministrationsCheck(
-        user,
-        titre.id,
-        etape.typeId,
-        'modification'
-      ))
-    ) {
+    const titreEtapePermission = await titreEtapePermissionAdministrationsCheck(
+      user,
+      titre.id,
+      etape.typeId,
+      'modification'
+    )
+
+    if (!titreEtapePermission) {
       throw new Error('droits insuffisants pour modifier cette étape')
     }
 

--- a/src/business/processes/titres-demarches-ordre-update.ts
+++ b/src/business/processes/titres-demarches-ordre-update.ts
@@ -24,7 +24,9 @@ const titresDemarchesOrdreUpdate = async (titres: ITitre[]) => {
             await titreDemarcheUpdate(
               titreDemarche.id,
               { ordre: index + 1 },
-              { fields: { id: {} } }
+              { fields: { id: {} } },
+              'super',
+              titre
             )
 
             console.info(

--- a/src/business/processes/titres-demarches-public-update.ts
+++ b/src/business/processes/titres-demarches-public-update.ts
@@ -41,9 +41,15 @@ const titresDemarchesPublicUpdate = async (titres: ITitre[]) => {
 
           if (Object.keys(publicUpdate).length) {
             queue.add(async () => {
-              await titreDemarcheUpdate(titreDemarche.id, publicUpdate, {
-                fields: { id: {} }
-              })
+              await titreDemarcheUpdate(
+                titreDemarche.id,
+                publicUpdate,
+                {
+                  fields: { id: {} }
+                },
+                'super',
+                titre
+              )
 
               console.info(
                 `mise à jour: démarche ${titreDemarche.id}, ${JSON.stringify(

--- a/src/business/processes/titres-demarches-public-update.ts
+++ b/src/business/processes/titres-demarches-public-update.ts
@@ -12,61 +12,55 @@ const titresDemarchesPublicUpdate = async (titres: ITitre[]) => {
 
   // TODO: forcer la présence des démarches sur le titre
   // https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist/49725198#49725198
-  const titresDemarchesUpdated = titres.reduce(
-    (titresDemarchesUpdated: string[], titre) =>
-      titre.demarches!.reduce(
-        (titresDemarchesUpdated: string[], titreDemarche) => {
-          const titreDemarcheEtapes = titreDemarche.etapes?.reverse() || []
 
-          const demarcheTypeEtapesTypes = titreDemarche.type!.etapesTypes!.filter(
-            et => et.titreTypeId === titre.typeId
+  const titresDemarchesUpdated = [] as string[]
+
+  titres.forEach(titre => {
+    titre.demarches!.forEach(titreDemarche => {
+      const titreDemarcheEtapes = titreDemarche.etapes?.reverse() || []
+
+      const demarcheTypeEtapesTypes = titreDemarche.type!.etapesTypes!.filter(
+        et => et.titreTypeId === titre.typeId
+      )
+
+      const { publicLecture, entreprisesLecture } = titreDemarchePublicFind(
+        titreDemarche.typeId,
+        demarcheTypeEtapesTypes,
+        titreDemarcheEtapes,
+        titre.typeId
+      )
+
+      const publicUpdate = {} as IPublicUpdate
+
+      if (titreDemarche.publicLecture !== publicLecture) {
+        publicUpdate.publicLecture = publicLecture
+      }
+
+      if (titreDemarche.entreprisesLecture !== entreprisesLecture) {
+        publicUpdate.entreprisesLecture = entreprisesLecture
+      }
+
+      if (Object.keys(publicUpdate).length) {
+        queue.add(async () => {
+          await titreDemarcheUpdate(
+            titreDemarche.id,
+            publicUpdate,
+            { fields: { id: {} } },
+            'super',
+            titre
           )
 
-          const { publicLecture, entreprisesLecture } = titreDemarchePublicFind(
-            titreDemarche.typeId,
-            demarcheTypeEtapesTypes,
-            titreDemarcheEtapes,
-            titre.typeId
+          console.info(
+            `mise à jour: démarche ${titreDemarche.id}, ${JSON.stringify(
+              publicUpdate
+            )}`
           )
+        })
 
-          const publicUpdate = {} as IPublicUpdate
-
-          if (titreDemarche.publicLecture !== publicLecture) {
-            publicUpdate.publicLecture = publicLecture
-          }
-
-          if (titreDemarche.entreprisesLecture !== entreprisesLecture) {
-            publicUpdate.entreprisesLecture = entreprisesLecture
-          }
-
-          if (Object.keys(publicUpdate).length) {
-            queue.add(async () => {
-              await titreDemarcheUpdate(
-                titreDemarche.id,
-                publicUpdate,
-                {
-                  fields: { id: {} }
-                },
-                'super',
-                titre
-              )
-
-              console.info(
-                `mise à jour: démarche ${titreDemarche.id}, ${JSON.stringify(
-                  publicUpdate
-                )}`
-              )
-
-              titresDemarchesUpdated.push(titreDemarche.id)
-            })
-          }
-
-          return titresDemarchesUpdated
-        },
-        titresDemarchesUpdated
-      ),
-    []
-  )
+        titresDemarchesUpdated.push(titreDemarche.id)
+      }
+    })
+  })
 
   await queue.onIdle()
 

--- a/src/business/processes/titres-demarches-statut-ids-update.ts
+++ b/src/business/processes/titres-demarches-statut-ids-update.ts
@@ -10,46 +10,39 @@ const titresDemarchesStatutUpdate = async (titres: ITitre[]) => {
 
   // TODO: forcer la présence des démarches sur le titre
   // https://stackoverflow.com/questions/40510611/typescript-interface-require-one-of-two-properties-to-exist/49725198#49725198
-  const titresDemarchesUpdated = titres.reduce(
-    (titresDemarchesUpdated: string[], titre) =>
-      titre.demarches!.reduce(
-        (titresDemarchesUpdated: string[], titreDemarche) => {
-          const titreDemarcheEtapes = titreDemarche.etapes?.reverse() || []
+  const titresDemarchesUpdated = [] as string[]
 
-          const statutId = titreDemarcheStatutIdFind(
-            titreDemarche.typeId,
-            titreDemarcheEtapes,
-            titre.typeId
+  titres.forEach(titre => {
+    titre.demarches!.forEach(titreDemarche => {
+      const titreDemarcheEtapes = titreDemarche.etapes?.reverse() || []
+
+      const statutId = titreDemarcheStatutIdFind(
+        titreDemarche.typeId,
+        titreDemarcheEtapes,
+        titre.typeId
+      )
+
+      if (titreDemarche.statutId !== statutId) {
+        queue.add(async () => {
+          await titreDemarcheUpdate(
+            titreDemarche.id,
+            { statutId },
+            { fields: { id: {} } },
+            'super',
+            titre
           )
 
-          if (titreDemarche.statutId === statutId) return titresDemarchesUpdated
+          console.info(
+            `mise à jour: démarche ${titreDemarche.id}, ${JSON.stringify({
+              statutId
+            })}`
+          )
+        })
 
-          queue.add(async () => {
-            await titreDemarcheUpdate(
-              titreDemarche.id,
-              {
-                statutId
-              },
-              { fields: { id: {} } },
-              'super',
-              titre
-            )
-
-            console.info(
-              `mise à jour: démarche ${titreDemarche.id}, ${JSON.stringify({
-                statutId
-              })}`
-            )
-
-            titresDemarchesUpdated.push(titreDemarche.id)
-          })
-
-          return titresDemarchesUpdated
-        },
-        titresDemarchesUpdated
-      ),
-    []
-  )
+        titresDemarchesUpdated.push(titreDemarche.id)
+      }
+    })
+  })
 
   await queue.onIdle()
 

--- a/src/business/processes/titres-demarches-statut-ids-update.ts
+++ b/src/business/processes/titres-demarches-statut-ids-update.ts
@@ -30,7 +30,9 @@ const titresDemarchesStatutUpdate = async (titres: ITitre[]) => {
               {
                 statutId
               },
-              { fields: { id: {} } }
+              { fields: { id: {} } },
+              'super',
+              titre
             )
 
             console.info(

--- a/src/database/cache/autorisations.ts
+++ b/src/database/cache/autorisations.ts
@@ -1,17 +1,13 @@
 import {
   IAutorisationTitreTypeAdministration,
   IAutorisationTitreTypeTitreStatut,
-  IRestrictionTitreTypeTitreStatutAdministration,
-  IAutorisationEtapeType,
-  IRestrictionTitreTypeEtapeTypeAdministration
+  IAutorisationEtapeType
 } from '../../types'
 
 import {
   autorisationsTitresTypesAdministrationsGet,
   autorisationsTitresTypesTitresStatutsGet,
-  restrictionsTitresTypesTitresStatutsAdministrationsGet,
-  autorisationsEtapesTypesGet,
-  restrictionsTitresTypesEtapesTypesAdministrationsGet
+  autorisationsEtapesTypesGet
 } from '../queries/autorisations'
 
 const autorisations = {
@@ -19,11 +15,6 @@ const autorisations = {
   statutsIds: [] as string[],
   typesStatuts: [] as IAutorisationTitreTypeTitreStatut[],
   titresTypesAdministrations: [] as IAutorisationTitreTypeAdministration[]
-}
-
-const restrictions = {
-  titresTypesTitresStatutsAdministrations: [] as IRestrictionTitreTypeTitreStatutAdministration[],
-  titresTypesEtapesTypesAdministrations: [] as IRestrictionTitreTypeEtapeTypeAdministration[]
 }
 
 const autorisationsInit = async () => {
@@ -44,10 +35,6 @@ const autorisationsInit = async () => {
   )
 
   autorisations.titresTypesAdministrations = await autorisationsTitresTypesAdministrationsGet()
-
-  restrictions.titresTypesTitresStatutsAdministrations = await restrictionsTitresTypesTitresStatutsAdministrationsGet()
-
-  restrictions.titresTypesEtapesTypesAdministrations = await restrictionsTitresTypesEtapesTypesAdministrationsGet()
 }
 
-export { autorisations, restrictions, autorisationsInit }
+export { autorisations, autorisationsInit }

--- a/src/database/queries/permissions/titres.ts
+++ b/src/database/queries/permissions/titres.ts
@@ -1,6 +1,6 @@
-import { IUtilisateur, IFields, IAdministration } from '../../../types'
+import { IAdministration, IFields, IUtilisateur } from '../../../types'
 
-import { raw, QueryBuilder } from 'objection'
+import { QueryBuilder, raw } from 'objection'
 import { permissionCheck } from '../../../tools/permission'
 
 import Titres from '../../models/titres'
@@ -12,9 +12,9 @@ import Administrations from '../../models/administrations'
 import Entreprises from '../../models/entreprises'
 
 import {
-  titreActivitesCalc,
   titreActivitePermissionQueryBuild,
-  titreActiviteQueryPropsBuild
+  titreActiviteQueryPropsBuild,
+  titreActivitesCalc
 } from './titres-activites'
 import { titreDemarchePermissionQueryBuild } from './titres-demarches'
 import { titreTravauxPermissionQueryBuild } from './titres-travaux'
@@ -61,7 +61,7 @@ const titresRestrictionsAdministrationQueryBuild = (
 
 const titresModificationQueryBuild = (
   administrations: IAdministration[],
-  type: 'titres' | 'demarches'
+  type: 'titres' | 'demarches' | 'etapes'
 ) =>
   Titres.query()
     .alias('titresModification')

--- a/src/database/queries/titres-demarches.ts
+++ b/src/database/queries/titres-demarches.ts
@@ -5,7 +5,8 @@ import {
   IColonne,
   IFields,
   Index,
-  IUtilisateur
+  IUtilisateur,
+  ITitre
 } from '../../types'
 import { transaction, Transaction, QueryBuilder } from 'objection'
 import TitresDemarches from '../models/titres-demarches'
@@ -17,6 +18,9 @@ import { fieldTitreAdd } from './graph/fields-add'
 
 import { titreDemarchePermissionQueryBuild } from './permissions/titres-demarches'
 import { titresFiltersQueryBuild } from './_titres-filters'
+import { permissionCheck } from '../../tools/permission'
+import { titreGet } from './titres'
+import { titreDemarchePermissionAdministrationsCheck } from '../../api/_permissions/titre-edition'
 
 const etapesIncluesExcluesBuild = (
   q: QueryBuilder<TitresDemarches, TitresDemarches[]>,
@@ -298,10 +302,37 @@ const titreDemarcheGet = async (
   return (await q.findById(titreDemarcheId)) as ITitreDemarche
 }
 
+/**
+ * Crée une nouvelle démarche
+ * @param titreDemarche - démarche à créer
+ * @param fields
+ * @param userId - id de l’utilisateur
+ * @returns la nouvelle démarche
+ */
 const titreDemarcheCreate = async (
   titreDemarche: ITitreDemarche,
-  { fields }: { fields?: IFields }
+  { fields }: { fields?: IFields },
+  userId?: string
 ) => {
+  const user = await userGet(userId)
+  if (!user || !permissionCheck(user?.permissionId, ['super', 'admin'])) {
+    throw new Error('droits insuffisants')
+  }
+
+  if (permissionCheck(user.permissionId, ['admin'])) {
+    const titre = await titreGet(titreDemarche.titreId, {}, user.id)
+    if (!titre) throw new Error("le titre n'existe pas")
+
+    if (
+      !(await titreDemarchePermissionAdministrationsCheck(
+        user,
+        titre.typeId,
+        titre.statutId!
+      ))
+    ) {
+      throw new Error('droits insuffisants pour créer cette démarche')
+    }
+  }
   const graph = fields
     ? graphBuild(fieldTitreAdd(fields), 'demarches', graphFormat)
     : options.titresDemarches.graph
@@ -320,8 +351,27 @@ const titreDemarcheDelete = async (id: string, trx?: Transaction) =>
 const titreDemarcheUpdate = async (
   id: string,
   props: Partial<ITitreDemarche>,
-  { fields }: { fields?: IFields }
+  { fields }: { fields?: IFields },
+  userId: string,
+  titre: ITitre
 ) => {
+  const user = await userGet(userId)
+
+  if (!user) {
+    throw new Error('droits insuffisants')
+  }
+
+  if (permissionCheck(user?.permissionId, ['admin'])) {
+    if (
+      !(await titreDemarchePermissionAdministrationsCheck(
+        user,
+        titre.typeId,
+        titre.statutId!
+      ))
+    ) {
+      throw new Error('droits insuffisants pour modifier cette démarche')
+    }
+  }
   const graph = fields
     ? graphBuild(fieldTitreAdd(fields), 'demarches', graphFormat)
     : options.titresDemarches.graph

--- a/src/database/queries/titres-demarches.ts
+++ b/src/database/queries/titres-demarches.ts
@@ -20,7 +20,7 @@ import { titreDemarchePermissionQueryBuild } from './permissions/titres-demarche
 import { titresFiltersQueryBuild } from './_titres-filters'
 import { permissionCheck } from '../../tools/permission'
 import { titreGet } from './titres'
-import { titreDemarchePermissionAdministrationsCheck } from '../../api/_permissions/titre-edition'
+import { titreTypeStatutPermissionAdministrationCheck } from '../../api/_permissions/titre-edition'
 
 const etapesIncluesExcluesBuild = (
   q: QueryBuilder<TitresDemarches, TitresDemarches[]>,
@@ -324,10 +324,11 @@ const titreDemarcheCreate = async (
     if (!titre) throw new Error("le titre n'existe pas")
 
     if (
-      !(await titreDemarchePermissionAdministrationsCheck(
+      !(await titreTypeStatutPermissionAdministrationCheck(
         user,
         titre.typeId,
-        titre.statutId!
+        titre.statutId!,
+        'demarches'
       ))
     ) {
       throw new Error('droits insuffisants pour créer cette démarche')
@@ -363,10 +364,11 @@ const titreDemarcheUpdate = async (
 
   if (permissionCheck(user?.permissionId, ['admin'])) {
     if (
-      !(await titreDemarchePermissionAdministrationsCheck(
+      !(await titreTypeStatutPermissionAdministrationCheck(
         user,
         titre.typeId,
-        titre.statutId!
+        titre.statutId!,
+        'demarches'
       ))
     ) {
       throw new Error('droits insuffisants pour modifier cette démarche')

--- a/src/database/queries/titres-demarches.ts
+++ b/src/database/queries/titres-demarches.ts
@@ -323,14 +323,14 @@ const titreDemarcheCreate = async (
     const titre = await titreGet(titreDemarche.titreId, {}, user.id)
     if (!titre) throw new Error("le titre n'existe pas")
 
-    if (
-      !(await titreTypeStatutPermissionAdministrationCheck(
-        user,
-        titre.typeId,
-        titre.statutId!,
-        'demarches'
-      ))
-    ) {
+    const titreTypeStatutPermission = await titreTypeStatutPermissionAdministrationCheck(
+      user,
+      titre.typeId,
+      titre.statutId!,
+      'demarches'
+    )
+
+    if (!titreTypeStatutPermission) {
       throw new Error('droits insuffisants pour créer cette démarche')
     }
   }
@@ -363,17 +363,18 @@ const titreDemarcheUpdate = async (
   }
 
   if (permissionCheck(user?.permissionId, ['admin'])) {
-    if (
-      !(await titreTypeStatutPermissionAdministrationCheck(
-        user,
-        titre.typeId,
-        titre.statutId!,
-        'demarches'
-      ))
-    ) {
+    const titreTypeStatutPermission = await titreTypeStatutPermissionAdministrationCheck(
+      user,
+      titre.typeId,
+      titre.statutId!,
+      'demarches'
+    )
+
+    if (!titreTypeStatutPermission) {
       throw new Error('droits insuffisants pour modifier cette démarche')
     }
   }
+
   const graph = fields
     ? graphBuild(fieldTitreAdd(fields), 'demarches', graphFormat)
     : options.titresDemarches.graph

--- a/src/database/queries/titres.ts
+++ b/src/database/queries/titres.ts
@@ -330,7 +330,7 @@ type ICount = {
  *
  * @param titre - titre à créer
  * @param fields - Non utilisés
- * @param user - utilisateur
+ * @param userId - id de l’utilisateur
  * @returns le nouveau titre
  *
  */

--- a/tests/titres-etapes-creer.test.ts
+++ b/tests/titres-etapes-creer.test.ts
@@ -102,7 +102,7 @@ describe('etapeCreer', () => {
     )
 
     expect(res.body.errors[0].message).toBe(
-      'statut de l\'étape "fai" invalide pour une type d\'étape acg pour une démarche de type octroi'
+      'droits insuffisants pour créer cette étape'
     )
   })
 

--- a/tests/titres-etapes-creer.test.ts
+++ b/tests/titres-etapes-creer.test.ts
@@ -47,7 +47,8 @@ async function demarcheCreate() {
       titreId,
       typeId: 'oct'
     },
-    {}
+    {},
+    'super'
   )
 
   return 'demarche-test-id'

--- a/tests/titres-etapes-modifier.test.ts
+++ b/tests/titres-etapes-modifier.test.ts
@@ -165,7 +165,7 @@ describe('etapeModifier', () => {
     )
 
     expect(res.body.errors[0].message).toBe(
-      'statut de l\'étape "fai" invalide pour une type d\'étape acg pour une démarche de type octroi'
+      'droits insuffisants pour modifier cette étape'
     )
   })
 

--- a/tests/titres-etapes-modifier.test.ts
+++ b/tests/titres-etapes-modifier.test.ts
@@ -49,7 +49,8 @@ async function etapeCreate() {
       titreId,
       typeId: 'oct'
     },
-    {}
+    {},
+    'super'
   )
 
   const titreEtapeId = 'etape-test-id'


### PR DESCRIPTION
J’ai volontairement éviter de bouger les méthodes de fichier pour éviter de compliquer la review.
