### PR TITLE
fix: corrige les logs avec plusieurs arguments

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -59,12 +59,12 @@ if (process.env.SENTRY_DSN) {
 
 app.listen(port, () => {
   console.info('')
-  console.info('> Url: ' + url + ' ')
-  console.info('> ENV: ' + process.env.ENV + ' ')
-  console.info('> NODE_ENV: ' + process.env.NODE_ENV + ' ')
+  console.info('URL:', url)
+  console.info('ENV:', process.env.ENV)
+  console.info('NODE_ENV:', process.env.NODE_ENV)
 
   if (process.env.NODE_DEBUG === 'true') {
-    console.warn('> NODE_DEBUG: ' + process.env.NODE_DEBUG + ' ')
+    console.warn('NODE_DEBUG:', process.env.NODE_DEBUG)
   }
   console.info('')
 })


### PR DESCRIPTION
Actuellement, on ne peut pas logguer plusieurs paramètres : `console.log('truc', monTruc)` au mieux, ça ne loggue que le premier argument, au pire ça fait planter l'application. 