### PR TITLE
fix(statistiques): corrige le caclcul des surfaces

### DIFF
--- a/src/api/graphql/resolvers/statistiques-granulats-marins.ts
+++ b/src/api/graphql/resolvers/statistiques-granulats-marins.ts
@@ -73,7 +73,9 @@ const statistiquesGranulatsMarinsInstantBuild = (titres: ITitre[]) => {
             acc.titresInstructionExploration++
           }
         } else {
-          acc.surfaceExploitation += titre.surfaceEtape.surface
+          if (['val', 'mod'].includes(titre.statutId)) {
+            acc.surfaceExploitation += titre.surfaceEtape.surface
+          }
           if (['mod', 'dmi'].includes(titre.statutId!)) {
             acc.titresInstructionExploitation++
           }


### PR DESCRIPTION
retire les 'dmi' des Surfaces cumulées des titres pouvant faire l'objet d'une activité
d’exploitation