### PR TITLE
fix(titres): vérifie le nombre de points du périmètre pour la requête de titres

### DIFF
--- a/src/api/graphql/resolvers/titres.ts
+++ b/src/api/graphql/resolvers/titres.ts
@@ -86,7 +86,6 @@ const titres = async (
 
     if (perimetre?.length !== 4) {
       throw new Error('un périmètre doit avoir 4 points')
-
     }
 
     const [titres, total] = await Promise.all([

--- a/src/api/graphql/resolvers/titres.ts
+++ b/src/api/graphql/resolvers/titres.ts
@@ -84,6 +84,10 @@ const titres = async (
     const user = await userGet(context.user?.id)
     const fields = fieldsBuild(info).elements
 
+    if (perimetre?.length !== 4) {
+      throw new Error('un périmètre doit avoir 4 points');
+    }
+
     const [titres, total] = await Promise.all([
       titresGet(
         {

--- a/src/api/graphql/resolvers/titres.ts
+++ b/src/api/graphql/resolvers/titres.ts
@@ -85,7 +85,8 @@ const titres = async (
     const fields = fieldsBuild(info).elements
 
     if (perimetre?.length !== 4) {
-      throw new Error('un périmètre doit avoir 4 points');
+      throw new Error('un périmètre doit avoir 4 points')
+
     }
 
     const [titres, total] = await Promise.all([


### PR DESCRIPTION
Bonjour, c'est encore moi !

J'espère que vous allez bien. :)
Une requête de ce type 

```graphql
{
  titres (perimetre: [1, 2, 3]) {
    nom
  }
}
```

provoque une erreur de binding knex.

Exemple :
https://api.camino.beta.gouv.fr/?query=%7B%0A%20%20titres(perimetre%3A%5B0%2C%202%2C%201%5D)%20%7B%0A%20%20%20%20elements%20%7B%0A%20%20%20%20%20%20nom%0A%20%20%20%20%7D%0A%20%20%7D%0A%7D

Je n'ai pas testé la PR en local car j'ai eu quelques difficultés à faire tourner le projet après plus de 6 mois d'absence (il me manque les sources des forêts semble-t-il), c'est donc repro + exemple de correction que je vous fournis.

À bientôt ! 👋 