### PR TITLE
feat(travaux): ajoute l'étape 'wpa' à la démarche 'dam'

### DIFF
--- a/src/knex/migrations-data/20211123084623_metas_travaux_publi_recueil_acte_admin_add.js
+++ b/src/knex/migrations-data/20211123084623_metas_travaux_publi_recueil_acte_admin_add.js
@@ -1,0 +1,16 @@
+exports.up = async knex => {
+  const demarcheTypeId = 'dam' // déclaration d'arrêt définitif des travaux
+  const etapeTypeId = 'wpa' // publication au recueil des actes administratifs
+  const titresTypes = await knex.select().table('titres_types')
+
+  for (const t of titresTypes) {
+    await knex('titres_types__demarches_types__etapes_types').insert({
+      titreTypeId: t.id,
+      demarcheTypeId,
+      etapeTypeId,
+      ordre: 230
+    })
+  }
+}
+
+exports.down = () => ({})


### PR DESCRIPTION
Complète https://trello.com/c/MkvaYuEF/35-featstatut-afficher-le-statut-des-d%C3%A9marches-travaux.

Le test et la cas existe déjà depuis la dernière PR (src/business/rules/titre-demarche-statut-id-find.test.ts ligne 414), il manquait juste de quoi faire apparaître WPA dans la création d'un DAM (via formulaire notamment).

Conformément au Cacoo de DADT (DAM) https://cacoo.com/diagrams/2LhuKgk0eAwMZxWQ/249D0, auquel Laure dit de se référer.