### PR TITLE
chore(test) accélère l'exécution des tests

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -54,11 +54,11 @@ const config: Config.InitialOptions = {
   globalTeardown: './tests/teardown.ts',
 
   // A set of global variables that need to be available in all test environments
-  // globals: {
-  //   'ts-jest': {
-  //     useESM: true
-  //   }
-  // },
+  globals: {
+    'ts-jest': {
+      isolatedModules: true
+    }
+  },
   // extensionsToTreatAsEsm: ['.ts'],
   // An array of directory names to be searched recursively up from the requiring module's location
   // moduleDirectories: [
@@ -81,7 +81,7 @@ const config: Config.InitialOptions = {
   // notifyMode: "always",
 
   // A preset that is used as a base for Jest's configuration
-  preset: 'ts-jest/presets/js-with-ts',
+  preset: 'ts-jest',
 
   // Run tests from one or more projects
   // projects: null,
@@ -156,11 +156,12 @@ const config: Config.InitialOptions = {
 
   // A map from regular expressions to paths to transformers
   // transform: {
-  //   '^.+\\.tsx?$': 'ts-jest'
+  //   '^.+\\.tsx?$': 'babel-jest'
   // },
+  maxWorkers: 1,
 
   // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
-  transformIgnorePatterns: ['/node_modules/', '<rootDir>/knex/*'],
+  transformIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/knex/*'],
 
   // An array of regexp pattern strings that are matched against all modules before the module loader will automatically return a mock for them
   // unmockedModulePathPatterns: undefined,

--- a/src/business/processes/administrations-update.test.ts
+++ b/src/business/processes/administrations-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { administrationsUpdate } from './administrations-update'
 import {

--- a/src/business/processes/entreprises-update.test.ts
+++ b/src/business/processes/entreprises-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { entreprisesUpdate } from './entreprises-update'
 import { entreprisesGet } from '../../database/queries/entreprises'

--- a/src/business/processes/titres-activites-props-update.test.ts
+++ b/src/business/processes/titres-activites-props-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresActivitesPropsUpdate } from './titres-activites-props-update'
 import { titresActivitesUpsert } from '../../database/queries/titres-activites'

--- a/src/business/processes/titres-activites-statut-ids-update.test.ts
+++ b/src/business/processes/titres-activites-statut-ids-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresActivitesStatutIdsUpdate } from './titres-activites-statut-ids-update'
 import { titresActivitesGet } from '../../database/queries/titres-activites'

--- a/src/business/processes/titres-activites-update.test.ts
+++ b/src/business/processes/titres-activites-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreActivite } from '../../types'
 

--- a/src/business/processes/titres-administrations-gestionnaires-update.test.ts
+++ b/src/business/processes/titres-administrations-gestionnaires-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreAdministrationGestionnaire } from '../../types'
 

--- a/src/business/processes/titres-contenus-etapes-ids-update.test.ts
+++ b/src/business/processes/titres-contenus-etapes-ids-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreEtape } from '../../types'
 

--- a/src/business/processes/titres-coordonnees-update.test.ts
+++ b/src/business/processes/titres-coordonnees-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import { titreCoordonneesFind } from '../utils/titre-coordonnees-find'
 import { titresGet } from '../../database/queries/titres'
 import Titres from '../../database/models/titres'

--- a/src/business/processes/titres-dates-update.test.ts
+++ b/src/business/processes/titres-dates-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresDatesUpdate } from './titres-dates-update'
 import { titreDateFinFind } from '../rules/titre-date-fin-find'

--- a/src/business/processes/titres-demarches-depot-create.test.ts
+++ b/src/business/processes/titres-demarches-depot-create.test.ts
@@ -3,7 +3,7 @@ import { titreDemarcheGet } from '../../database/queries/titres-demarches'
 import TitresDemarches from '../../database/models/titres-demarches'
 import { titresEtapesDepotCreate } from './titres-demarches-depot-create'
 import * as titresDemarchesDepotCreateMethods from './titres-demarches-depot-create'
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 jest.mock('../../database/queries/titres-demarches', () => ({
   titreDemarcheGet: jest.fn()

--- a/src/business/processes/titres-demarches-ordre-update.test.ts
+++ b/src/business/processes/titres-demarches-ordre-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresDemarchesOrdreUpdate } from './titres-demarches-ordre-update'
 import { titresGet } from '../../database/queries/titres'

--- a/src/business/processes/titres-demarches-public-update.test.ts
+++ b/src/business/processes/titres-demarches-public-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresDemarchesPublicUpdate } from './titres-demarches-public-update'
 import { titresGet } from '../../database/queries/titres'

--- a/src/business/processes/titres-demarches-statut-ids-update.test.ts
+++ b/src/business/processes/titres-demarches-statut-ids-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresDemarchesStatutIdUpdate } from './titres-demarches-statut-ids-update'
 import { titresGet } from '../../database/queries/titres'

--- a/src/business/processes/titres-etapes-administrations-locales-update.test.ts
+++ b/src/business/processes/titres-etapes-administrations-locales-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresEtapesAdministrationsLocalesUpdate } from './titres-etapes-administrations-locales-update'
 import {

--- a/src/business/processes/titres-etapes-areas-update.test.ts
+++ b/src/business/processes/titres-etapes-areas-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { IGeometry } from '../../types'
 

--- a/src/business/processes/titres-etapes-ordre-update.test.ts
+++ b/src/business/processes/titres-etapes-ordre-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresEtapesOrdreUpdate } from './titres-etapes-ordre-update'
 import { titreEtapeUpdate } from '../../database/queries/titres-etapes'

--- a/src/business/processes/titres-phases-update.test.ts
+++ b/src/business/processes/titres-phases-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import { titresPhasesUpdate } from './titres-phases-update'
 import {
   titrePhasesUpsert,

--- a/src/business/processes/titres-points-references-create.test.ts
+++ b/src/business/processes/titres-points-references-create.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresPointsReferencesCreate } from './titres-points-references-create'
 import {

--- a/src/business/processes/titres-props-etapes-ids-update.test.ts
+++ b/src/business/processes/titres-props-etapes-ids-update.test.ts
@@ -1,5 +1,5 @@
 import { ITitreEtape } from '../../types'
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titresPropsEtapesIdsUpdate } from './titres-props-etapes-ids-update'
 import { titrePropTitreEtapeFind } from '../rules/titre-prop-etape-find'

--- a/src/business/processes/titres-public-update.test.ts
+++ b/src/business/processes/titres-public-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import { titresPublicUpdate } from './titres-public-update'
 import { titresGet } from '../../database/queries/titres'
 

--- a/src/business/processes/titres-slugs-update.test.ts
+++ b/src/business/processes/titres-slugs-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import Titres from '../../database/models/titres'
 import { titresSlugsUpdate } from './titres-slugs-update'

--- a/src/business/processes/titres-statut-ids-update.test.ts
+++ b/src/business/processes/titres-statut-ids-update.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import { titresStatutIdsUpdate } from './titres-statut-ids-update'
 import { titresGet } from '../../database/queries/titres'
 

--- a/src/business/rules-demarches/_utils.test.ts
+++ b/src/business/rules-demarches/_utils.test.ts
@@ -1,7 +1,7 @@
 import fs from 'fs'
 import decamelize from 'decamelize'
 import camelcase from 'camelcase'
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import {
   IDemarcheType,

--- a/src/business/rules/titre-activites-build.test.ts
+++ b/src/business/rules/titre-activites-build.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import {
   IActiviteType,
   ITitreActivite,

--- a/src/business/utils/contenu-element-file-process.test.ts
+++ b/src/business/utils/contenu-element-file-process.test.ts
@@ -1,6 +1,6 @@
 import { FileUpload } from 'graphql-upload'
 import { ReadStream } from 'fs'
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { IContenu, IContenuElement, ISection, ITitreEtape } from '../../types'
 

--- a/src/business/utils/titre-activite-valide-check.test.ts
+++ b/src/business/utils/titre-activite-valide-check.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreDemarche } from '../../types'
 

--- a/src/business/utils/titre-coordonnees-find.test.ts
+++ b/src/business/utils/titre-coordonnees-find.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { titreCoordonneesFind } from './titre-coordonnees-find'
 import { geojsonCenter } from '../../tools/geojson'

--- a/src/business/utils/titre-etape-heritage-contenu-find.test.ts
+++ b/src/business/utils/titre-etape-heritage-contenu-find.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import {
   IContenu,

--- a/src/business/utils/titre-valide-check.test.ts
+++ b/src/business/utils/titre-valide-check.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreDemarche } from '../../types'
 

--- a/src/business/validations/titre-etape-type-and-status-validate.test.ts
+++ b/src/business/validations/titre-etape-type-and-status-validate.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 import { IEtapeType } from '../../types'
 
 import { titreEtapeTypeAndStatusValidate } from './titre-etape-type-and-status-validate'

--- a/tests/entreprises.test.ts
+++ b/tests/entreprises.test.ts
@@ -1,4 +1,4 @@
-import { mocked } from 'ts-jest/utils'
+import { mocked } from 'jest-mock'
 
 import { ITitreEtapeJustificatif } from '../src/types'
 import { dbManager } from './db-manager'


### PR DESCRIPTION
* accélère l'exécution des tests
* supprime l'avertissement de librairie obsolète

Pour la totalité des tests unitaires (ceux dans src)  on passe à moins de 2 minutes (compilation incluse), et quelques secondes pour lancer un test seul (au lieu de parfois plus d'une minute)

Prochaine étape, rendre les tests parallélisables à nouveau
